### PR TITLE
update soft404 to be compatible with webstruct >= 0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six
 langdetect==1.0.6
 lxml==3.6.4
 numpy==1.11.1
-parsel==1.0.3
+parsel==1.1.0
 scikit-learn==0.17.1
-scipy==0.18.0
-webstruct==0.3
+scipy==0.18.1
+webstruct==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'parsel',
         'scikit-learn',
         'scipy',
-        'webstruct>=0.3',
+        'webstruct>=0.4',
     ],
     long_description=read('README.rst'),
     classifiers=[

--- a/soft404/utils.py
+++ b/soft404/utils.py
@@ -7,7 +7,7 @@ from lxml import etree
 from lxml.html.clean import Cleaner
 import parsel
 import numpy as np
-from webstruct.feature_extraction import HtmlTokenizer
+from webstruct.html_tokenizer import HtmlTokenizer
 
 
 _clean_html = Cleaner(


### PR DESCRIPTION
webstruct 0.4 broke backwards compatibility: HtmlTokenizer was moved to its own module.