### PR TITLE
require scipy 0.18+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,17 @@ Changes
 
 .. contents::
 
+??? (TBA)
+---------
+
+- packaging fix: scipy > 0.18 is required to use the prebuilt model
+
 0.2.0 (2017-01-19)
 ------------------
 
 - Python 2.7 support for prediction
 - require (and work on) scikit-learn 0.18+
+- fixed support for recent webstruct versions
 - improve model accuracy, remove numeric features
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'html_text',
         'numpy',
         'scikit-learn>=0.18',
-        'scipy',
+        'scipy>=0.18',
         'webstruct>=0.4',
     ],
     long_description=read('README.rst'),


### PR DESCRIPTION
With scipy < 0.18 `soft404.probability(...)` fails with a traceback:

```
In [2]: soft404.probability('<h1>404</h1>')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-ee8c8c8505c8> in <module>()
----> 1 soft404.probability('<h1>404</h1>')

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/soft404/predict.py in probability(html)
     30     if default_classifier is None:
     31         default_classifier = Soft404Classifier()
---> 32     return default_classifier.predict(html)
     33
     34

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/soft404/predict.py in predict(self, html)
     17         """ Return probability of the page being a 404 page.
     18         """
---> 19         return float(self.pipeline.predict_proba([html])[0, 1])
     20
     21     @classmethod

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/sklearn/utils/metaestimators.py in <lambda>(*args, **kwargs)
     52
     53         # lambda, but not partial, allows help() to work with update_wrapper
---> 54         out = lambda *args, **kwargs: self.fn(obj, *args, **kwargs)
     55         # update the docstring of the returned function
     56         update_wrapper(out, self.fn)

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/sklearn/pipeline.py in predict_proba(self, X)
    374         for name, transform in self.steps[:-1]:
    375             if transform is not None:
--> 376                 Xt = transform.transform(Xt)
    377         return self.steps[-1][-1].predict_proba(Xt)
    378

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/sklearn/feature_extraction/text.py in transform(self, X, copy)
   1079                                      n_features, expected_n_features))
   1080             # *= doesn't work
-> 1081             X = X * self._idf_diag
   1082
   1083         if self.norm:

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/scipy/sparse/base.py in __mul__(self, other)
    317             if self.shape[1] != other.shape[0]:
    318                 raise ValueError('dimension mismatch')
--> 319             return self._mul_sparse_matrix(other)
    320
    321         try:

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/scipy/sparse/compressed.py in _mul_sparse_matrix(self, other)
    476
    477         major_axis = self._swap((M,N))[0]
--> 478         other = self.__class__(other)  # convert to this format
    479
    480         idx_dtype = get_index_dtype((self.indptr, self.indices,

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/scipy/sparse/compressed.py in __init__(self, arg1, shape, dtype, copy)
     26
     27         if isspmatrix(arg1):
---> 28             if arg1.format == self.format and copy:
     29                 arg1 = arg1.copy()
     30             else:

/Users/kmike/envs/deep-deep/lib/python3.6/site-packages/scipy/sparse/base.py in __getattr__(self, attr)
    523             return self.getnnz()
    524         else:



--> 525             raise AttributeError(attr + " not found")
    526
    527     def transpose(self):

AttributeError: format not found
```